### PR TITLE
Content for GAI/QTS v1

### DIFF
--- a/app/views/auth/finish.html
+++ b/app/views/auth/finish.html
@@ -1,5 +1,5 @@
 {% extends "layouts/forms.html" %}
-{% set title %}You've created a Teaching Services account{% endset %}
+{% set title %}You've created a teaching services account{% endset %}
 
 
 {% block form %}
@@ -8,7 +8,7 @@
 <p>Next time, you can sign in just using your email <strong>({{ data.email or 'email@example.com' }})</strong>.</p>
 
 
-<p class="govuk-!-margin-bottom-6">Continue to apply for QTS </p>
+<p class="govuk-!-margin-bottom-6">Continue to Apply for QTS in England. </p>
 
 
 

--- a/app/views/auth/ga-account.html
+++ b/app/views/auth/ga-account.html
@@ -1,6 +1,6 @@
 {% extends "layouts/forms.html" %}
-{% set title = "You need a Teaching Services account to continue" %}
-{% set title %}You need a {{serviceName}} to continue{% endset%}
+{% set title = "You need a teaching services account to continue" %}
+{% set title %}Create a teaching services account{% endset%}
 
 {% set hideButton = true %}
 
@@ -8,17 +8,24 @@
 
 {% block form %}
   <h1 class="govuk-heading-xl">{{ title }}</h1>
-  <p>A {{serviceName}} lets you:</p>
+
+
+  <p>It will only take a few minutes and you’ll need:</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>
-      access different teaching services with one login
+      an email address (used for contact and account security)
     </li>
     <li>
-      update your details in one place
+      a mobile phone number (used for account security)
     </li>
-  
+    <li>
+      your name and date of birth
+    </li>
+
   </ul>
-  
+
+  <p>Once you've created an account, you can continue to Apply for QTS in England.</p>
+
   {{ govukButton({
     text: 'Create an account',
     href: 'email'
@@ -30,5 +37,19 @@
     <a href="/sign-in/email">Sign in</a> to using your existing account details.
   </p>
 
-  
+  <details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      About teaching services accounts
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    Teaching services accounts are new. They let teachers and teaching professionals access different DfE services with one login. You can also update your details with DfE in one place.
+  </div>
+  <div class="govuk-details__text">
+    At the moment there are only a few DfE services using teaching services accounts. In the future, you’ll be able to use your teaching services account to sign in to most DfE teaching services.
+  </div>
+</details>
+
+
 {% endblock %}

--- a/app/views/auth/start.html
+++ b/app/views/auth/start.html
@@ -32,12 +32,12 @@ Apply for qualified teacher status (QTS) in England
       <h1 class="govuk-heading-xl">
         Apply for qualified teacher status (QTS) in England
       </h1>
-      <p class="govuk-heading-m">Who this service is for:</p>
+      <p class="govuk-heading-m">Who this service is for</p>
 
       <p>This service is for qualified teachers who trained to teach outside of England who want to apply for qualified teacher status (QTS) to teach in English schools.        </p>
 
 
-    <p> If you trained in England or Wales, or have not yet qualified, <a href="#">more about other routes to QTS</a>.        </p>
+    <p> If you trained in England or Wales, or have not yet qualified, <a href="#">learn more about other routes to QTS</a>.        </p>
 
        <p>Use this service to:</p>
 
@@ -49,11 +49,15 @@ Apply for qualified teacher status (QTS) in England
       <p>We’ll ask some questions to check your eligibility to apply for QTS in England. This should take about 5 minutes.</p>
 
        <p>There’s no charge to apply for QTS. You do not need to be in the UK to use this service.</p>
-        
-       <p>You need to create a {{serviceName}} to apply for qualified teacher status (QTS).</p>
 
        <p>If you’ve already started your application using this service, you can <a href='#'>sign in to continue working on it.</a></p>
-        
+
+       <p class="govuk-heading-m">Teaching services account</p>
+
+       <p>You’ll need to create a teaching services account to Apply for QTS in England. You can use do this at the start of this service.</p>
+
+
+
       <a href="ga-account.html" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
         Start now
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">


### PR DESCRIPTION
Setting out the steps for account creation in GAI lite.

Content added to and changed on the following pages:
- QTS start
- identity account
- identity finish