### PR TITLE
20 April updates

### DIFF
--- a/app/assets/javascripts/disable-browser-autofill.js
+++ b/app/assets/javascripts/disable-browser-autofill.js
@@ -22,8 +22,6 @@ function disableBrowserAutofill () {
     window.NodeList.prototype.forEach = Array.prototype.forEach
   }
 
-  console.log("Running!")
-
   document.querySelectorAll('form').forEach(form => {
 
     let inputs = [...form.querySelectorAll('input')]

--- a/app/assets/javascripts/disable-browser-autofill.js
+++ b/app/assets/javascripts/disable-browser-autofill.js
@@ -1,0 +1,58 @@
+// Disable browser autofill
+
+// This code is used to force the disabling of browser autofill. It’s needed
+// for browsers that ignore the `autocomplete="off"` attribute.
+
+// To use, add `data-js-disable-browser-autofill='on'` either on a form
+// element or on individual inputs where autofill should be disabled.
+
+// ## Accessibility
+// The solution relies on setting the `autocomplete` attribute to a
+// non-standard attribute. This may be considered a fail for WCAG 1.3.5 -
+// Identify Input Purpose. However, we accept this is a necessary and
+// worthwhile tradeoff for the benefits of preventing browser autofill on
+// inputs where it shouldn’t appear.
+
+function disableBrowserAutofill () {
+  const dataAttributeName = 'data-nameoriginal'
+  const inputTypes = ['text', 'tel', 'email', 'number']
+
+  // Missing forEach on NodeList for IE11
+  if (window.NodeList && !window.NodeList.prototype.forEach) {
+    window.NodeList.prototype.forEach = Array.prototype.forEach
+  }
+
+  console.log("Running!")
+
+  document.querySelectorAll('form').forEach(form => {
+
+    let inputs = [...form.querySelectorAll('input')]
+      .filter(input => inputTypes.includes(input.type))
+
+    if (form.dataset.jsDisableBrowserAutofill === 'on'){
+      inputs = inputs.filter(input => input.dataset.jsDisableBrowserAutofill !== 'off')
+    } else {
+      inputs = inputs.filter(input => input.dataset.jsDisableBrowserAutofill === 'on')
+    }
+
+    if (inputs.length) {
+
+      inputs.forEach(input => {
+        // The autocomplete attribute needs to be set to a non-standard attribute
+        // for the solution to work
+        input.setAttribute('autocomplete', 'disabled')
+        input.setAttribute(dataAttributeName, input.name)
+        input.name = Math.random().toString(36).substring(7) // NOSONAR
+      })
+
+      form.addEventListener('submit', () => {
+        inputs.forEach(input => {
+          input.name = input.getAttribute(dataAttributeName)
+        })
+      })
+
+    }
+  })
+}
+
+disableBrowserAutofill()

--- a/app/data/dqtUsers.json
+++ b/app/data/dqtUsers.json
@@ -5,7 +5,7 @@
     "middleNames": "",
     "lastNames": "S mith",
     "email": "v.smith@example.com",
-    "dateOfBirth": "2001-01-11T00:00:00.000Z",
+    "dateOfBirth": "1990-01-11T00:00:00.000Z",
     "trn": "100300155"
   },
  {
@@ -14,7 +14,7 @@
     "middleNames": "Jane",
     "lastNames": "Smith",
     "email": "s.smith@example.com",
-    "dateOfBirth": "2001-01-11T00:00:00.000Z",
+    "dateOfBirth": "1996-01-11T00:00:00.000Z",
     "trn": "032943032"
   },
   {
@@ -30,7 +30,7 @@
     "id": "e09a4127-5c50-4544-a414-b4d7e75f5c9f",
     "firstNames": "Michael",
     "middleNames": "",
-    "lastNames": "Berger",
+    "lastNames": "B erger",
     "email": "m.berger@example.com",
     "dateOfBirth": "1999-10-21T00:00:00.000Z",
     "trn": "100458383"

--- a/app/filters/names.js
+++ b/app/filters/names.js
@@ -1,0 +1,41 @@
+// First, middle, last
+
+var filters = {}
+
+
+filters.getFullName = user => {
+
+  let names = []
+
+  // Prefer DQT Name
+  if (user?.dqtUser){
+    names.push(user.dqtUser.firstNames)
+    names.push(user.dqtUser.middleNames)
+    names.push(user.dqtUser.lastNames)
+  }
+  else {
+    names.push(user.firstNames)
+    names.push(user.middleNames)
+    names.push(user.lastNames)
+  }
+
+  names.filter(Boolean)
+  return names.join(' ')
+}
+
+// First and last
+filters.getShortName = user => {
+
+  let names = []
+  // Prefer DQT Name
+  if (user?.dqtUser){
+    names.push(user.dqtUser.firstNames)
+    names.push(user.dqtUser.lastNames)
+  }
+  else {
+    names.push(user.firstNames)
+    names.push(user.lastNames)
+  }
+  names.filter(Boolean)
+  return names.join(' ')
+}

--- a/app/views/_includes/forms/evidence-needed.html
+++ b/app/views/_includes/forms/evidence-needed.html
@@ -9,8 +9,10 @@
     <li>driving licence</li>
     <li>passport</li>
   {% else %}
+    <li>birth certificate</li>
     <li>civil partnership certificate</li>
     <li>decree absolute</li>
+    <li>driving licence</li>
     <li>deed poll</li>
     <li>marriage certificate</li>
     <li>passport</li>

--- a/app/views/_layouts/forms.html
+++ b/app/views/_layouts/forms.html
@@ -34,7 +34,7 @@
        {% endif %}
 
 
-      <form {{formActionHtml | safe }} method="post" novalidate spellcheck="false">
+      <form {{formActionHtml | safe }} method="post" novalidate spellcheck="false" data-js-disable-browser-autofill="on">
         {% block form %}{% endblock %}
         {% if not hideButton %}
         {{ govukButton({

--- a/app/views/auth/_email.html
+++ b/app/views/auth/_email.html
@@ -5,6 +5,8 @@
       text: "",
       classes: "govuk-label--s "
     },
+    type: "email",
+    autocomplete: "off",
     errorMessage: {
       text: data['errorMessageCopy']
     } if data['errorMessage'] == 'true'

--- a/app/views/auth/_phone.html
+++ b/app/views/auth/_phone.html
@@ -1,3 +1,5 @@
+
+
 {%- if auth -%}
   <p>Add your mobile number to make your account more secure. We’ll send a security code to this number by text message. </p>
 {%- else -%}
@@ -12,7 +14,7 @@
       classes: "govuk-label--s"
     },
     type: "tel",
-    autocomplete: "tel",
+    autocomplete: "off",
     hint: {
       html: "For international numbers include the country code"
     },

--- a/app/views/auth/email.html
+++ b/app/views/auth/email.html
@@ -2,6 +2,10 @@
 {% set title %}Your email address{% endset %}
 {% set emailHint %}We’ll use this to send you a code to confirm your email address. Do not use a work or university email that you might lose access to.{% endset %}
 
+{% block pageScripts %}
+  <script src="/public/javascripts/disable-browser-autofill.js"></script>
+{% endblock %}
+
 {% block form %}
   {% include 'auth/_email.html' %}
 {% endblock %}

--- a/app/views/auth/phone.html
+++ b/app/views/auth/phone.html
@@ -2,6 +2,10 @@
 {% set title %}Your mobile number{% endset %}
 {% set auth = 'true' %}
 
+{% block pageScripts %}
+  <script src="/public/javascripts/disable-browser-autofill.js"></script>
+{% endblock %}
+
 {% block form %}
   {% include 'auth/_phone.html' %}
 {% endblock %}


### PR DESCRIPTION
Adds some code to disable browser autofill on the mobile and email fields - on production we'd want autofill, but for user research we'd rather not have participant's details coming on screen.

Also tweaks the ages of the scenarios to make them a bit older.