### PR TITLE
Prompt users to move away from institution email addresses

### DIFF
--- a/app/data/dqtUsers.json
+++ b/app/data/dqtUsers.json
@@ -4,7 +4,7 @@
     "firstNames": "Victoria",
     "middleNames": "",
     "lastNames": "S mith",
-    "email": "v.smith@example.com",
+    "email": "v.smith@huddersfield.ac.uk",
     "dateOfBirth": "1990-01-11T00:00:00.000Z",
     "trn": "100300155"
   },

--- a/app/lib/utils.js
+++ b/app/lib/utils.js
@@ -20,3 +20,30 @@ exports.dateOfBirthHasChanged = (previousUser, newUser) => {
 
   return previousDate.getTime() != newDate.getTime()
 }
+
+
+exports.emailIsEducationDomain = email => {
+
+  if (!email) return false
+
+  let emailParts = email.split("@")
+
+  let emailSuffix = emailParts[1]
+
+  let educationDomains = [
+    "ac.uk",
+    "gov.uk",
+    "sch.uk",
+    "academy",
+    "school",
+    "college"
+    ]
+
+  let emailIsEducation = educationDomains.some(domain => emailSuffix.toLowerCase().includes(domain) )
+
+  if (emailIsEducation){
+    console.log(`Email ${emailSuffix} is likely educational`)
+  }
+
+  return emailIsEducation
+}

--- a/app/routes/auth-lite.js
+++ b/app/routes/auth-lite.js
@@ -3,28 +3,69 @@ const utils = require('./../lib/utils')
 
 module.exports = router => {
 
+
+  router.get('/auth/start', (req, res) => { 
+    const data = req.session.data
+
+    let user = data.user
+
+    let emailIsEducationDomain = utils.emailIsEducationDomain(user.email)
+
+    if (emailIsEducationDomain){
+      res.redirect('/auth/institution-email')
+    }
+    else {
+      res.redirect('/auth/phone')
+    }
+  })
+
   router.post('/auth/email', (req, res) => {
-    if(req.session.data['email'] == 'head@school.com') {
+    const data = req.session.data
+    if(req.session.data?.user?.email == 'head@school.com') {
       const data = req.session.data
       data.errorMessage = 'true'
       res.redirect('/auth/email')
     } else {
-      const data = req.session.data
       data.matchAccountEmail = 'false'
       data.errorMessage = 'false'
       res.redirect('/auth/email-code')     
     }
     })
 
+  router.post('/auth/institution-email', (req, res) => {
+    const data = req.session.data
+
+    if (data.user.changeEmail == 'yes'){
+      
+      data.user.email = data.user.newEmail
+      delete data.user.changeEmail
+      delete dta.user.newEmail
+      res.redirect('/auth/email-code')   
+    }
+    else {
+      delete data.user.changeEmail
+      res.redirect('/auth/phone')
+    }
+    })
+
   router.post('/auth/email-code', (req, res) => {
-    if(req.session.data['email'] == 'existing@email.com') {
-      const data = req.session.data
-      data.phoneMatch = 'false'
-      data.matchAccount = 'true'
-      res.redirect('/auth/sign-in-interstitial')
-    } else if(req.session.data['emailAuth'] == 'true') {
+    // if(req.session.data['email'] == 'existing@email.com') {
+    //   const data = req.session.data
+    //   data.phoneMatch = 'false'
+    //   data.matchAccount = 'true'
+    //   res.redirect('/auth/sign-in-interstitial')
+    // } else if(req.session.data['emailAuth'] == 'true') {
+    //   // res.redirect('/auth/check-answers')
+    //   res.redirect('/auth/phone')
+    // } else {
+    //   res.redirect('/auth/phone')
+    // }
+    const data = req.session.data
+
+    if (data?.user?.phone){
       res.redirect('/auth/check-answers')
-    } else {
+    }
+    else {
       res.redirect('/auth/phone')
     }
   })

--- a/app/routes/auth-lite.js
+++ b/app/routes/auth-lite.js
@@ -7,9 +7,9 @@ module.exports = router => {
   router.get('/auth/start', (req, res) => { 
     const data = req.session.data
 
-    let user = data.user
+    let user = data.user || {}
 
-    let emailIsEducationDomain = utils.emailIsEducationDomain(user.email)
+    let emailIsEducationDomain = utils.emailIsEducationDomain(user?.email)
 
     if (emailIsEducationDomain){
       res.redirect('/auth/institution-email')

--- a/app/views/auth/_ga-account.html
+++ b/app/views/auth/_ga-account.html
@@ -14,7 +14,7 @@
     text: 'Create an account',
     classes: "app-button--inverse",
     href: accountPath,
-    href: '/auth/phone'
+    href: '/auth/start'
   }) }}
 
   <h1 class="govuk-heading-m">Already have an account?</h1>

--- a/app/views/auth/_institution-email.html
+++ b/app/views/auth/_institution-email.html
@@ -31,7 +31,7 @@ We recommend setting your DfE Identity account up with a personal email address.
   name: "user[changeEmail]",
   fieldset: {
     legend: {
-      text: "Which email address would you like use for your DfE Identity account?",
+      text: "Which email address would you like to use for your DfE Identity account?",
       isPageHeading: false,
       classes: "govuk-fieldset__legend--s"
     }

--- a/app/views/auth/_institution-email.html
+++ b/app/views/auth/_institution-email.html
@@ -1,0 +1,55 @@
+<p class="govuk-body">
+We recommend setting your DfE Identity account up with a personal email address. This is so you will not lose access to it if you move to another work or education setting.
+</p>
+
+{% set emailHtml %}
+  {{ govukInput({
+    id: "[email]",
+    name: "user[newEmail]",
+    label: {
+      text: "Email address"
+    },
+    type: "email",
+    autocomplete: "off",
+    errorMessage: {
+      text: data['errorMessageCopy']
+    } if data['errorMessage'] == 'true'
+    ,
+    hint: {
+      html: emailHint
+    },
+    classes: 'govuk-!-width-two-thirds'
+  }) }}
+
+{% endset %}
+
+{% set labelForNo %}
+  Use <span class="govuk-!-font-weight-bold">{{data.user.email}}</span>
+{% endset %}
+
+{{ govukRadios({
+  name: "user[changeEmail]",
+  fieldset: {
+    legend: {
+      text: "Which email address would you like use for your DfE Identity account?",
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--s"
+    }
+  },
+  items: [
+    {
+      value: "yes",
+      text: "Enter a personal email address",
+      conditional: {
+        html: emailHtml
+      }
+    },
+    {
+      value: "no",
+      html: labelForNo
+    }
+  ]
+}) }}
+
+
+

--- a/app/views/auth/_resend-email.html
+++ b/app/views/auth/_resend-email.html
@@ -13,7 +13,7 @@
   hint: {
     html: emailHint
   },
-  value: data['email'] or email
+  value: data.user.email or email
 }) }}
 
 {% endset -%}

--- a/app/views/auth/_summary-card.html
+++ b/app/views/auth/_summary-card.html
@@ -161,7 +161,7 @@
 }) if data['emailAuth'] != 'true' }}
 
 <p class="govuk-body">
-  Check the details we have you from your DfE teacher record.
+  Check the details we have for you from your DfE teacher record.
 </p>
 
 <p class="govuk-body">
@@ -177,7 +177,7 @@
   
 {% endset %}
 
-
+<h2 class="govuk-heading-m">Personal details</h2>
 {{ govukSummaryList({
   classes: "govuk-!-margin-bottom-9",
   titleText: "Personal details",
@@ -227,53 +227,60 @@
       }]
     }
   },
+  {
+    key: {
+      html: 'Date of birth'
+    },
+    value: {
+      text: data.user.dateOfBirth | govukDate
+    },
+    actions: {
+      items: [{
+        text: 'Change',
+        href: "date-of-birth",
+        visuallyHiddenText: "date of birth"
+      }]
+    }
+  }
+  ]
+})}}
+
+
+<h2 class="govuk-heading-m">Sign in details</h2>
+{{ govukSummaryList({
+  classes: "govuk-!-margin-bottom-9",
+  rows: [
     {
       key: {
-        html: 'Date of birth'
+        html: 'Email'
       },
       value: {
-        text: data.user.dateOfBirth | govukDate
+        html: data.user.email or data.defaultData.email
+
       },
       actions: {
         items: [{
           text: 'Change',
-          href: "date-of-birth",
-          visuallyHiddenText: "date of birth"
+          href: "email",
+          visuallyHiddenText: "email"
         }]
       }
     },
-  {
-    key: {
-      html: 'Mobile phone'
-    },
-    value: {
-      html: data.user.phone or data.defaultData.phone
+    {
+      key: {
+        html: 'Mobile phone'
+      },
+      value: {
+        html: data.user.phone or data.defaultData.phone
 
-    },
-    actions: {
-      items: [{
-        text: 'Change',
-        href: "phone",
-        visuallyHiddenText: "mobile phone"
-      }]
+      },
+      actions: {
+        items: [{
+          text: 'Change',
+          href: "phone",
+          visuallyHiddenText: "mobile phone"
+        }]
+      }
     }
-  },
-  {
-    key: {
-      html: 'Email'
-    },
-    value: {
-      html: data.user.email or data.defaultData.email
-
-    },
-    actions: {
-      items: [{
-        text: 'Change',
-        href: "email",
-        visuallyHiddenText: "email"
-      }]
-    }
-
-  }
   ]
-}) if data['emailAuth'] == 'true' or  data['dqt'] == 'false'}}
+})}}

--- a/app/views/auth/check-answers.html
+++ b/app/views/auth/check-answers.html
@@ -1,6 +1,10 @@
 {% extends "_layouts/forms.html" %}
 {% set title = "Confirm your details" %}
 
+{% set buttonText = "Confirm" %}
+
 {% block form %}
-      {% include '../auth/_summary-card.html' %}
+
+  {% include '../auth/_summary-card.html' %}
+
 {% endblock %}

--- a/app/views/auth/emails/qts-email.html
+++ b/app/views/auth/emails/qts-email.html
@@ -4,7 +4,9 @@
 
 {% set userShortName = (data.user or data.defaultData) | getShortName %}
 
-{% set emailNameTo = userShortName %}
+{% set emailNameTo %}
+  {{userShortName}} <{{data.user.email}}>
+{% endset %}
 
 {% block content %}
   <p>Dear {{ userShortName }},</p>

--- a/app/views/auth/institution-email.html
+++ b/app/views/auth/institution-email.html
@@ -1,0 +1,10 @@
+{% extends "_layouts/forms.html" %}
+{% set title %}Your email address looks like it’s from a work or education setting{% endset %}
+
+{% block pageScripts %}
+  <script src="/public/javascripts/disable-browser-autofill.js"></script>
+{% endblock %}
+
+{% block form %}
+  {% include 'auth/_institution-email.html' %}
+{% endblock %}


### PR DESCRIPTION
Many of the email addresses we have in DQT are institution / education addresses - we'd prefer that users register with their personal address though.

This adds a conditional page to the dqt journey where we detect the existing email address may be from an academic institution.

Changing isn't required.