### PR TITLE
Add preferred name question

### DIFF
--- a/app/data/dqtUsers.json
+++ b/app/data/dqtUsers.json
@@ -1,10 +1,10 @@
 [
   {
     "id": "14f71042-3fc3-4671-98d7-bf9b117d5583",
-    "firstNames": "Victoria",
+    "firstNames": "Jessica",
     "middleNames": "",
-    "lastNames": "S mith",
-    "email": "v.smith@huddersfield.ac.uk",
+    "lastNames": "Smith",
+    "email": "j.smith@huddersfield.ac.uk",
     "dateOfBirth": "1990-01-11T00:00:00.000Z",
     "trn": "100300155"
   },

--- a/app/filters.js
+++ b/app/filters.js
@@ -14,6 +14,7 @@ Object.keys(utils).forEach(filterName => addFilter(filterName, utils[filterName]
 // Import filters from filters folder
 if (fs.existsSync(individualFiltersFolder)) {
   var files = fs.readdirSync(individualFiltersFolder)
+  console.log(`Importing files: ${files.length}`)
   files.forEach(file => {
     let fileData = require(path.join(individualFiltersFolder, file))
     // Loop through each exported function in file (likely just one)
@@ -21,16 +22,17 @@ if (fs.existsSync(individualFiltersFolder)) {
       // Get each method from the file
       Object.keys(fileData[filterGroup]).forEach(filterName => {
         // filters[filterName] = fileData[filterGroup][filterName]
+        console.log(`Adding filter ${filterName}`)
         addFilter(filterName, fileData[filterGroup][filterName])
       })
     })
   })
 }
 
-addFilter('getShortName',function(user) {
-  if (!user) return ''
-  else return `${user.firstNames} ${user.lastNames}`
-})
+// addFilter('getShortName',function(user) {
+//   if (!user) return ''
+//   else return `${user.firstNames} ${user.lastNames}`
+// })
 
 addFilter('stringify',function(object) {
   return JSON.stringify(object)

--- a/app/filters/names.js
+++ b/app/filters/names.js
@@ -9,17 +9,19 @@ filters.getFullName = user => {
 
   // Prefer DQT Name
   if (user?.dqtUser){
-    names.push(user.dqtUser.firstNames)
-    names.push(user.dqtUser.middleNames)
-    names.push(user.dqtUser.lastNames)
+    names.push(user?.dqtUser?.firstNames)
+    names.push(user?.dqtUser?.middleNames)
+    names.push(user?.dqtUser?.lastNames)
   }
   else {
-    names.push(user.firstNames)
-    names.push(user.middleNames)
-    names.push(user.lastNames)
+    names.push(user?.firstNames)
+    names.push(user?.middleNames)
+    names.push(user?.lastNames)
   }
 
-  names.filter(Boolean)
+  names = names.filter(Boolean)
+  console.log(`Full name: ${names}`)
+  console.log(`Full name: ${names.join(' ')}`)
   return names.join(' ')
 }
 
@@ -29,13 +31,20 @@ filters.getShortName = user => {
   let names = []
   // Prefer DQT Name
   if (user?.dqtUser){
-    names.push(user.dqtUser.firstNames)
-    names.push(user.dqtUser.lastNames)
+    names.push(user?.dqtUser?.firstNames)
+    names.push(user?.dqtUser?.lastNames)
   }
   else {
-    names.push(user.firstNames)
-    names.push(user.lastNames)
+    names.push(user?.firstNames)
+    names.push(user?.lastNames)
   }
-  names.filter(Boolean)
+  names = names.filter(Boolean)
+  console.log(`Short name: ${names.join(' ')}`)
   return names.join(' ')
 }
+
+
+// -------------------------------------------------------------------
+// keep the following line to return your filters to the app
+// -------------------------------------------------------------------
+exports.filters = filters

--- a/app/routes/auth-lite.js
+++ b/app/routes/auth-lite.js
@@ -120,22 +120,40 @@ module.exports = router => {
 
   })
 
+  let updatePreferredName = user => {
+
+    let preferredName = user.preferredName
+
+    if (preferredName == 'custom'){
+      user.preferredName = user.preferredNameCustom
+      delete user.preferredNameCustom
+    }
+
+    return user
+
+  }
+
   router.post('/auth/preferred-name', (req, res) => {
     const data = req.session.data
 
-    let preferredName = data.user.preferredName
+    data.user = updatePreferredName(data.user)
 
-    console.log(`Preferred name was ${preferredName}`)
+    if (!data.user.preferredName){
+      res.redirect('/auth/preferred-name')
+    }
+    else {
+      res.redirect('/auth/check-answers')
+    }
 
-    if (preferredName == 'custom'){
-      if (!data.user.preferredNameCustom){
-        res.redirect('/auth/preferred-name')
-      }
-      else {
-        data.user.preferredName = data.user.preferredNameCustom
-        delete data.user.preferredNameCustom
-        res.redirect('/auth/check-answers')
-      }
+  })
+
+  router.post('/auth/update-preferred-name', (req, res) => {
+    const data = req.session.data
+
+    data.user = updatePreferredName(data.user)
+
+    if (!data.user.preferredName){
+      res.redirect('/auth/update-preferred-name')
     }
     else {
       res.redirect('/auth/check-answers')
@@ -145,13 +163,14 @@ module.exports = router => {
 
 
   router.post(['/auth/name'], (req, res, next) => {
-    req.session.data['fullName'] = `${req.body['firstName']} ${req.body['lastName']}`
-    if(req.session.data['emailAuth'] == 'true') {
-      res.redirect('/auth/check-answers')
-      // res.redirect('/auth/date-of-birth')
-    } else {
-      res.redirect('/auth/date-of-birth')    }
-   
+    // req.session.data['fullName'] = `${req.body['firstName']} ${req.body['lastName']}`
+    // if(req.session.data['emailAuth'] == 'true') {
+    //   res.redirect('/auth/check-answers')
+    //   // res.redirect('/auth/date-of-birth')
+    // } else {
+    //   res.redirect('/auth/date-of-birth')    }
+
+    res.redirect('/auth/update-preferred-name')
   })
 
   router.post('/auth/date-of-birth', (req, res) => { 

--- a/app/routes/auth-lite.js
+++ b/app/routes/auth-lite.js
@@ -104,19 +104,44 @@ module.exports = router => {
       res.redirect('/auth/phone-code')
     }
     // Ed todo: this is probably broken now as I have changed the mobile numbers in use
-    else if(req.session.data['phone'] == '07827999618') {
-      const data = req.session.data
-      data.phoneMatch = 'true'
-      data.matchAccount = 'true'
-      res.redirect('/auth/sign-in-interstitial')
-    } else if(req.session.data['emailAuth'] == 'true') {
-      res.redirect('/auth/check-answers')
-    } 
+    // else if(req.session.data['phone'] == '07827999618') {
+    //   const data = req.session.data
+    //   data.phoneMatch = 'true'
+    //   data.matchAccount = 'true'
+    //   res.redirect('/auth/sign-in-interstitial')
+    // } 
+
     else {
-      res.redirect('/auth/name')
+      if (data.user.preferredName){
+        res.redirect('/auth/check-answers')
+      }
+      else res.redirect('/auth/preferred-name')
     }
+
   })
 
+  router.post('/auth/preferred-name', (req, res) => {
+    const data = req.session.data
+
+    let preferredName = data.user.preferredName
+
+    console.log(`Preferred name was ${preferredName}`)
+
+    if (preferredName == 'custom'){
+      if (!data.user.preferredNameCustom){
+        res.redirect('/auth/preferred-name')
+      }
+      else {
+        data.user.preferredName = data.user.preferredNameCustom
+        delete data.user.preferredNameCustom
+        res.redirect('/auth/check-answers')
+      }
+    }
+    else {
+      res.redirect('/auth/check-answers')
+    }
+
+  })
 
 
   router.post(['/auth/name'], (req, res, next) => {
@@ -277,6 +302,8 @@ module.exports = router => {
   router.post('/auth/finish', (req, res) => { res.redirect('/auth/return-to-service') })
 
   router.post('/auth/phone', (req, res) => { res.redirect('/auth/phone-code') })
+
+  router.post('/auth/preferred-name', (req, res) => { res.redirect('/auth/check-answers') })
   router.post('/auth/phone-radio', (req, res) => { res.redirect('/auth/phone-code') })
 
 }

--- a/app/routes/auth-lite.js
+++ b/app/routes/auth-lite.js
@@ -39,7 +39,7 @@ module.exports = router => {
       
       data.user.email = data.user.newEmail
       delete data.user.changeEmail
-      delete dta.user.newEmail
+      delete data.user.newEmail
       res.redirect('/auth/email-code')   
     }
     else {

--- a/app/views/_includes/forms/preferred-name.html
+++ b/app/views/_includes/forms/preferred-name.html
@@ -1,3 +1,7 @@
+{% set shortName = data.user | getShortName %}
+{% set fullName = data.user | getFullName %}
+{% set preferredName = data.user.preferredName %}
+
 {% set freeTextInput %}
   {{ govukInput({
     label: {
@@ -11,11 +15,6 @@
   }) }}
 {% endset %}
 
-{% set shortName = data.user | getShortName %}
-{% set fullName = data.user | getFullName %}
-
-{% set preferredName = data.user.preferredName %}
-
 {{ govukRadios({
   name: "user[preferredName]",
   fieldset: {
@@ -26,7 +25,7 @@
     }
   },
   hint: {
-    html: "For example, Mike Smith instead of Michael Smith.<br><br>We’ll use this in correspondence, it will not be displayed on your teaching certificates."
+    html: "For example, Mike Smith instead of Michael Smith.<br><br>We’ll use your preferred name in correspondence. We use official names on teaching certificates."
   },
   items: [
     {
@@ -48,4 +47,3 @@
   ],
   value: preferredName
 }) }}
-

--- a/app/views/_includes/forms/preferred-name.html
+++ b/app/views/_includes/forms/preferred-name.html
@@ -1,0 +1,45 @@
+{% set freeTextInput %}
+  {{ govukInput({
+    label: {
+      text: "Your preferred name",
+      _classes: "govuk-label--l",
+      isPageHeading: false
+    },
+    value: data.user.preferredName,
+    id: "custom-preferred-name",
+    name: "user[preferredNameCustom]"
+  }) }}
+{% endset %}
+
+{{ govukRadios({
+  name: "user[preferredName]",
+  fieldset: {
+    legend: {
+      text: title,
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  hint: {
+    html: "For example, Mike Smith instead of Michael Smith.<br><br>We’ll use this in correspondence, it will not be displayed on your teaching certificates."
+  },
+  items: [
+    {
+      value: "Victoria Smith",
+      text: "Use Victoria Smith"
+    },
+    {
+      value: "Victoria Nelson Smith",
+      text: "Use Victoria Nelson Smith"
+    },
+    {
+      value: "custom",
+      text: "Other",
+      conditional: {
+        html: freeTextInput
+      },
+      checked: true if data.user.preferredName
+    }
+  ],
+  value: data.user.preferredName
+}) }}

--- a/app/views/_includes/forms/preferred-name.html
+++ b/app/views/_includes/forms/preferred-name.html
@@ -11,6 +11,11 @@
   }) }}
 {% endset %}
 
+{% set shortName = data.user | getShortName %}
+{% set fullName = data.user | getFullName %}
+
+{% set preferredName = data.user.preferredName %}
+
 {{ govukRadios({
   name: "user[preferredName]",
   fieldset: {
@@ -25,21 +30,22 @@
   },
   items: [
     {
-      value: "Victoria Smith",
-      text: "Use Victoria Smith"
+      value: shortName,
+      text: "Use " + shortName
     },
     {
-      value: "Victoria Nelson Smith",
-      text: "Use Victoria Nelson Smith"
-    },
+      value: fullName,
+      text: "Use " + fullName
+    } if fullName != shortName,
     {
       value: "custom",
       text: "Other",
       conditional: {
         html: freeTextInput
       },
-      checked: true if data.user.preferredName
+      checked: true if (preferredName and preferredName != shortName and preferredName != fullName)
     }
   ],
-  value: data.user.preferredName
+  value: preferredName
 }) }}
+

--- a/app/views/_includes/forms/update-preferred-name.html
+++ b/app/views/_includes/forms/update-preferred-name.html
@@ -1,0 +1,54 @@
+{% set shortName = data.user | getShortName %}
+{% set fullName = data.user | getFullName %}
+{% set preferredName = data.user.preferredName %}
+
+{% set freeTextInput %}
+  {{ govukInput({
+    label: {
+      text: "Your preferred name",
+      _classes: "govuk-label--l",
+      isPageHeading: false
+    },
+    value: data.user.preferredName,
+    id: "custom-preferred-name",
+    name: "user[preferredNameCustom]"
+  }) }}
+{% endset %}
+
+{{ govukRadios({
+  name: "user[preferredName]",
+  fieldset: {
+    legend: {
+      text: title,
+      isPageHeading: true,
+      classes: "govuk-fieldset__legend--l"
+    }
+  },
+  hint: {
+    html: "For example, Mike Smith instead of Michael Smith.<br><br>We’ll use your preferred name in correspondence. We use official names on teaching certificates."
+  },
+  items: [
+    {
+      value: data.user.preferredName,
+      text: "Keep " + data.user.preferredName
+    } if data.user.preferredName,
+    {
+      value: shortName,
+      text: "Use " + shortName
+    },
+    {
+      value: fullName,
+      text: "Use " + fullName
+    } if fullName != shortName,
+    {
+      value: "custom",
+      text: "Other",
+      conditional: {
+        html: freeTextInput
+      },
+      checked: true if (preferredName and preferredName != shortName and preferredName != fullName),
+      checked: false
+    }
+  ],
+  value: preferredName
+}) }}

--- a/app/views/account/_summary-card.html
+++ b/app/views/account/_summary-card.html
@@ -1,5 +1,5 @@
 {% set officialName %}
-  {{ data.dqtName }}
+  {{ data.user | getFullName }}
   <p class="govuk-hint govuk-!-font-size-14">Displayed on teaching certificates </p>
   {% if data['nameLozenge'] %}
  {% include '_includes/_lozenge.html' %}
@@ -23,13 +23,18 @@
 {% endset %}
 
 {% set verifiedDOB %}
-{{ data.dob | isoDateFromDateInput | govukDate if data['dob'] else '1 December 1989' }}
-  {% if data['verifiedDob'] == 'true' %}
-  <p class="govuk-hint govuk-!-font-size-14">Your verified date of birth.</p>
+  {{ data.dob | isoDateFromDateInput | govukDate if data['dob'] else '1 December 1989' }}
+{% endset %}
+
+{% set middleNamesHtml %}
+  {% if data.user.middleNames %}
+    {{data.user.middleNames}}
+  {% else %}
+    <span class="govuk-hint">Not provided</span>
   {% endif %}
 {% endset %}
 
-<h3 class="govuk-heading-m">Personal details</h3>
+<h3 class="govuk-heading-m">Teaching record</h3>
 
 {{ govukSummaryList({
   classes: "govuk-!-margin-bottom-9",
@@ -37,21 +42,7 @@
   rows: [
   {
     key: {
-      html: 'Name'
-    },
-    value: {
-      html: data['fullName'] if data['firstName'] else 'Ria Smith'
-    },
-    actions: {
-      items: [{
-        text: 'Change',
-        href: "name"
-      }]
-    }
-  },
-  {
-    key: {
-      html: 'Official name'
+      html: 'Full name'
     },
     value: {
       html: officialName
@@ -62,7 +53,52 @@
         href: "name-dqt-overview"
       }]
     } if data['nameLozenge'] != "show"
-  } if data['showDqtName'] == "show",
+  } if data['showDqtName'] == "show" and false,
+  {
+    key: {
+      html: 'First names'
+    },
+    value: {
+      html: data.user.firstNames
+    },
+    actions: {
+      items: [{
+        text: 'Change',
+        href: "name",
+        visuallyHiddenText: "first names"
+      }]
+    }
+  },
+  {
+    key: {
+      html: 'Middle names'
+    },
+    value: {
+      html: middleNamesHtml
+    },
+    actions: {
+      items: [{
+        text: 'Change',
+        href: "name",
+        visuallyHiddenText: "middle names"
+      }]
+    }
+  },
+  {
+    key: {
+      html: 'Last names'
+    },
+    value: {
+      html: data.user.lastNames
+    },
+    actions: {
+      items: [{
+        text: 'Change',
+        href: "name",
+        visuallyHiddenText: "last names"
+      }]
+    }
+  },
   {
     key: {
       html: 'Date of birth'
@@ -75,7 +111,7 @@
         text: 'Change',
         href: "date-of-birth"
       }]
-    } if data['verifiedDob'] == "false"
+    }
   } if data['showDqtDob'] != "show",
   {
     key: {
@@ -108,60 +144,84 @@
   ]
 }) }}
 
-<h3 class="govuk-heading-m">Sign in details</h3>
+<h3 class="govuk-heading-m">Account details</h3>
+{% set preferredNameHtml %}
+  {% if data.user.preferredName %}
+    {{data.user.preferredName}}
+  {% else %}
+    <span class="govuk-hint">Not provided</span>
+  {% endif %}
+{% endset %}
 
 {{ govukSummaryList({
   classes: "govuk-!-margin-bottom-9",
   titleText: "Personal details",
   rows: [
-  {
-    key: {
-      html: 'Email'
+    {
+      key: {
+        html: 'Preferred name'
+      },
+      value: {
+        html: preferredNameHtml
+      },
+      actions: {
+        items: [{
+          text: 'Change',
+          href: "preferred-name",
+          visuallyHiddenText: "preferredName"
+        }]
+      }
     },
-    value: {
-      html: data['email'] if data['email'] else 'email@example.com'
+    {
+      key: {
+        html: 'Email'
+      },
+      value: {
+        html: data.user.email
 
+      },
+      actions: {
+        items: [{
+          text: 'Change',
+          href: "email"
+        }]
+      }
     },
-    actions: {
-      items: [{
-        text: 'Change',
-        href: "email"
-      }]
+    {
+      key: {
+        html: 'Mobile number'
+      },
+      value: {
+        html: data.user.phone
+
+      },
+      actions: {
+        items: [{
+          text: 'Change',
+          href: "phone"
+        }]
+      }
     }
-  },
-  {
-    key: {
-      html: 'Mobile number'
-    },
-    value: {
-      html: data['phone'] if data['phone'] else '07827999617'
+    ]
+  }) }}
+{# {% if data['showDqtDob'] == "show" or data['showDqtName'] == "show" %} #}
+{% if data.user.trn %}
 
-    },
-    actions: {
-      items: [{
-        text: 'Change',
-        href: "phone"
-      }]
+  <h3 class="govuk-heading-m">Teacher reference number (TRN)</h3>
+
+  {{ govukSummaryList({
+    classes: "govuk-!-margin-bottom-9",
+    titleText: "Personal details",
+    rows: [
+    {
+      key: {
+        html: 'TRN'
+      },
+      value: {
+        html: data.user.trn
+
+      }
     }
-  }
-  ]
-}) }}
-{% if data['showDqtDob'] == "show" or data['showDqtName'] == "show" %}
-<h3 class="govuk-heading-m">Teacher reference number (TRN)</h3>
-
-{{ govukSummaryList({
-  classes: "govuk-!-margin-bottom-9",
-  titleText: "Personal details",
-  rows: [
-  {
-    key: {
-      html: 'TRN'
-    },
-    value: {
-      html: data['trn'] if data['trn'] else '1851018'
-
-    }
-  }
-  ]
-}) }}
+    ]
+  }) }}
 {% endif %}

--- a/app/views/auth/_summary-card.html
+++ b/app/views/auth/_summary-card.html
@@ -184,7 +184,7 @@
   {% endif %}
 {% endset %}
 
-<h2 class="govuk-heading-m">Personal details</h2>
+<h2 class="govuk-heading-m">Teaching record</h2>
 {{ govukSummaryList({
   classes: "govuk-!-margin-bottom-9",
   titleText: "Personal details",
@@ -236,21 +236,6 @@
   },
   {
     key: {
-      html: 'Preferred name'
-    },
-    value: {
-      html: preferredNameHtml
-    },
-    actions: {
-      items: [{
-        text: 'Change',
-        href: "preferred-name",
-        visuallyHiddenText: "preferredName"
-      }]
-    }
-  },
-  {
-    key: {
       html: 'Date of birth'
     },
     value: {
@@ -268,10 +253,25 @@
 })}}
 
 
-<h2 class="govuk-heading-m">Sign in details</h2>
+<h2 class="govuk-heading-m">Account details</h2>
 {{ govukSummaryList({
   classes: "govuk-!-margin-bottom-9",
   rows: [
+    {
+      key: {
+        html: 'Preferred name'
+      },
+      value: {
+        html: preferredNameHtml
+      },
+      actions: {
+        items: [{
+          text: 'Change',
+          href: "preferred-name",
+          visuallyHiddenText: "preferredName"
+        }]
+      }
+    },
     {
       key: {
         html: 'Email'

--- a/app/views/auth/_summary-card.html
+++ b/app/views/auth/_summary-card.html
@@ -169,12 +169,19 @@
 </p>
 
 {% set middleNamesHtml %}
-{% if data.user.middleNames %}
-  {{data.user.middleNames}}
-{% else %}
-  <span class="govuk-hint">Not provided</span>
-{% endif %}
-  
+  {% if data.user.middleNames %}
+    {{data.user.middleNames}}
+  {% else %}
+    <span class="govuk-hint">Not provided</span>
+  {% endif %}
+{% endset %}
+
+{% set preferredNameHtml %}
+  {% if data.user.preferredName %}
+    {{data.user.preferredName}}
+  {% else %}
+    <span class="govuk-hint">Not provided</span>
+  {% endif %}
 {% endset %}
 
 <h2 class="govuk-heading-m">Personal details</h2>
@@ -224,6 +231,21 @@
         text: 'Change',
         href: "name",
         visuallyHiddenText: "last names"
+      }]
+    }
+  },
+  {
+    key: {
+      html: 'Preferred name'
+    },
+    value: {
+      html: preferredNameHtml
+    },
+    actions: {
+      items: [{
+        text: 'Change',
+        href: "preferred-name",
+        visuallyHiddenText: "preferredName"
       }]
     }
   },

--- a/app/views/auth/_summary-card.html
+++ b/app/views/auth/_summary-card.html
@@ -161,7 +161,7 @@
 }) if data['emailAuth'] != 'true' }}
 
 <p class="govuk-body">
-  Check the details we have for you from your DfE teacher record.
+  Check the details we have for you from your DfE teaching record.
 </p>
 
 <p class="govuk-body">

--- a/app/views/auth/evidence-needed.html
+++ b/app/views/auth/evidence-needed.html
@@ -4,9 +4,9 @@
 {% set dobChanged = data.user | dateOfBirthHasChanged(data.user.dqtUser) %}
 
 {% if nameChanged and dobChanged %}
-  {% set title = "You’ll need to provide evidence for this name and date of birth change" %}
+  {% set title = "You’ll need to provide evidence for this official name and date of birth change" %}
 {% elseif nameChanged %}
-  {% set title = "You’ll need to provide evidence for this name change" %}
+  {% set title = "You’ll need to provide evidence for this official name change" %}
 {% elseif dobChanged %}
   {% set title = "You’ll need to provide evidence for this date of birth change" %}
   

--- a/app/views/auth/name.html
+++ b/app/views/auth/name.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/forms.html" %}
-{% set title %}Change the name we have for you in our records{% endset %}
+{% set title %}Change your official name on your teacher record{% endset %}
 {% set signedIn = 'false' %}
 
 {% block form %}

--- a/app/views/auth/preferred-name.html
+++ b/app/views/auth/preferred-name.html
@@ -1,0 +1,12 @@
+{% extends "_layouts/forms.html" %}
+{% set title %}Do you have a preferred name?{% endset %}
+{% set auth = 'true' %}
+{% set showheader = true %}
+
+{# {% block pageScripts %}
+  <script src="/public/javascripts/disable-browser-autofill.js"></script>
+{% endblock %} #}
+
+{% block form %}
+  {% include "_includes/forms/preferred-name.html" %}
+{% endblock %}

--- a/app/views/auth/preferred-name.html
+++ b/app/views/auth/preferred-name.html
@@ -1,5 +1,5 @@
 {% extends "_layouts/forms.html" %}
-{% set title %}Do you have a preferred name?{% endset %}
+{% set title %}What is your preferred name?{% endset %}
 {% set auth = 'true' %}
 {% set showheader = true %}
 

--- a/app/views/auth/update-preferred-name.html
+++ b/app/views/auth/update-preferred-name.html
@@ -1,0 +1,12 @@
+{% extends "_layouts/forms.html" %}
+{% set title %}Do you want to update your preferred name?{% endset %}
+{% set auth = 'true' %}
+{% set showheader = true %}
+
+{# {% block pageScripts %}
+  <script src="/public/javascripts/disable-browser-autofill.js"></script>
+{% endblock %} #}
+
+{% block form %}
+  {% include "_includes/forms/update-preferred-name.html" %}
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -35,7 +35,7 @@
     <a href="/auth/emails/qts-email">Email - access your QTS cert</a>
   </p>
   <p>
-    <a href="/invite/14f71042-3fc3-4671-98d7-bf9b117d5583">New invite link - Victoria s mith</a>
+    <a href="/invite/14f71042-3fc3-4671-98d7-bf9b117d5583">New invite link - Jessica Smith</a>
   </p>
   <p>
     <a href="/invite/98610705-d34c-4282-8480-45646ed5cfe1">New invite link - Sarah Jane Smith</a>


### PR DESCRIPTION
Adds a question asking about the user's preferred name. This is asked in addition to the first, middle and last names. We can use these names to offer suggestions for options for preferred name.

Initial page:
<img width="1018" alt="Screenshot 2023-05-26 at 11 50 18" src="https://github.com/DFE-Digital/dfe-identity-account-prototype/assets/2204224/e39f37d6-f3f5-48b0-9907-00b001345d61">

Users can choose to pick their own preferred name. We're nudging them towards providing a full name, but they could provide us anything here
<img width="1017" alt="Screenshot 2023-05-26 at 11 50 57" src="https://github.com/DFE-Digital/dfe-identity-account-prototype/assets/2204224/a9980b50-0404-471a-aedb-602c0b9c31a3">

Updated summary screen separating training details from account details
<img width="1029" alt="Screenshot 2023-05-26 at 11 51 47" src="https://github.com/DFE-Digital/dfe-identity-account-prototype/assets/2204224/8f14c9d8-9721-490f-9b82-eb32fbcdc41e">

If a user edits their official name we can show a conditional page prompting them to update their preferred name
<img width="1022" alt="Screenshot 2023-05-26 at 11 56 18" src="https://github.com/DFE-Digital/dfe-identity-account-prototype/assets/2204224/1c8fb830-6726-4f7d-b14f-bfa6119e40ea">
